### PR TITLE
fix: re-anchor wasm path to module location (closes #5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Compile-binary smoke test (BUG-001 regression)
         run: tests/smoke/run-compile-smoke.sh
 
+      - name: Consumer-install smoke test (gh #5 regression)
+        run: tests/smoke/run-consumer-install-smoke.sh
+
       - name: No-execution guard (test surface must never shell out)
         run: |
           # Test files parse shell strings; they must never execute them.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@questi0nm4rk/shell-ast",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Full AST exposure for shell scripts via mvdan/sh compiled to WASM",
   "license": "MIT",
   "repository": {

--- a/src/wasm.ts
+++ b/src/wasm.ts
@@ -1,23 +1,57 @@
 // WASM bridge to the Go shell-ast processor.
 //
-// Asset loading uses Bun import attributes so paths are not resolved at
-// runtime via import.meta.dirname (which `bun build --compile` would
-// snapshot to the build-machine's absolute path — see docs/BUGS.md
-// BUG-001 and docs/AUDIT.md A1).
+// Path resolution must work in three modes:
+//   (a) dev `bun test` / `bun run` against src/ — wasm lives in
+//       sibling dist/ directory
+//   (b) consumer `import "@questi0nm4rk/shell-ast"` after `bun add` —
+//       wasm lives in the same directory as the bundled index.js
+//   (c) `bun build --compile` standalone binary — wasm is embedded
+//       inside the binary's $bunfs/ filesystem
 //
-// `with { type: "file" }` returns a real path in dev and a $bunfs/...
-// embedded path in compiled binaries; readFile works in both.
+// Anchoring against `fileURLToPath(import.meta.url)` covers all three:
+// dev → src/wasm.ts URL, consumer → dist/index.js URL (which gets
+// joined with the sibling wasm), compile → $bunfs URL (binary self-
+// contained). The `../dist/` vs `./` divergence between dev and
+// consumer is reconciled by deriving the wasm filename inline below
+// and letting the bundler rewrite the import path.
+//
+// Earlier history (see docs/BUGS.md BUG-001 and docs/AUDIT.md A1):
+//   - v0.1.0 used `import.meta.dirname` directly → BUG-001 baked the
+//     build-machine path into `bun build --compile` output
+//   - v0.2.0 used `with { type: "file" }` → bundler emitted a
+//     CWD-relative string literal that broke every consumer not
+//     running from dist/ (gh issue #5)
+//   - v0.2.1 (this): fileURLToPath(import.meta.url) → preserved as a
+//     runtime expression by the bundler; resolves correctly in all
+//     three modes
 //
 // The shim is a side-effect import — wasm_exec.js is an IIFE that
-// registers `globalThis.Go` when evaluated. Bun bundles it inline in
-// dev and in compiled binaries.
+// registers `globalThis.Go` when evaluated. Bun bundles it inline
+// in dev and in compiled binaries.
 //
 // loadWasm() caches its in-flight promise so concurrent first-callers
 // share a single instantiation (audit A3).
 
 import { readFile } from "node:fs/promises";
+import { dirname, isAbsolute, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import "./wasm_exec.js";
-import wasmPath from "../dist/shell-ast.wasm" with { type: "file" };
+import wasmAsset from "../dist/shell-ast.wasm" with { type: "file" };
+
+// `with { type: "file" }` returns:
+//   - dev (bun run / bun test on src/): an absolute disk path
+//   - bun build --compile: an absolute $bunfs/... path (embedded)
+//   - bun build --target node: a CWD-relative literal like
+//     "./shell-ast.wasm" — this is the v0.2.0 regression (gh #5)
+//
+// Re-anchor a relative result against the module's own directory
+// (dist/index.js's location for consumer installs). Absolute paths
+// are passed through untouched so both dev and --compile keep
+// working unchanged.
+const here = dirname(fileURLToPath(import.meta.url));
+const wasmPath = isAbsolute(wasmAsset)
+  ? wasmAsset
+  : join(here, wasmAsset.replace(/^\.\//, ""));
 
 // WebAssembly.Imports isn't exported in all lib targets; derive the
 // expected type from instantiate's signature.

--- a/tests/smoke/run-consumer-install-smoke.sh
+++ b/tests/smoke/run-consumer-install-smoke.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Consumer-install smoke test for gh issue #5 (v0.2.0 regression).
+#
+# Packs the package via `bun pm pack`, installs the tarball into a
+# throwaway scratch directory, and runs a consumer script from THAT
+# directory. The bundled `dist/index.js` must resolve its wasm
+# anchored to the module location, not to process.cwd().
+#
+# This catches the v0.2.0 class of bug where `with { type: "file" }`
+# was emitting a CWD-relative literal — every consumer outside the
+# package directory ENOENT'd on first parse().
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRATCH="${TMPDIR:-/tmp}/sa-consumer-$$"
+TGZ_NAME=""
+
+cleanup() {
+  local rc=$?
+  rm -rf "$SCRATCH"
+  [ -n "$TGZ_NAME" ] && rm -f "$REPO_ROOT/$TGZ_NAME"
+  exit "$rc"
+}
+trap cleanup EXIT
+
+cd "$REPO_ROOT"
+
+# Preconditions: a built dist must exist.
+[ -f dist/index.js ] || { echo "[consumer-smoke] missing dist/index.js — run 'bun run build' first"; exit 2; }
+[ -f dist/shell-ast.wasm ] || { echo "[consumer-smoke] missing dist/shell-ast.wasm"; exit 2; }
+
+echo "[consumer-smoke] packing tarball"
+PACK_OUTPUT=$(bun pm pack 2>&1)
+TGZ_NAME=$(echo "$PACK_OUTPUT" | grep -oE 'questi0nm4rk-shell-ast-[0-9.]+\.tgz' | head -1)
+[ -n "$TGZ_NAME" ] || { echo "[consumer-smoke] couldn't determine tarball name from: $PACK_OUTPUT"; exit 1; }
+
+echo "[consumer-smoke] scratch dir: $SCRATCH"
+mkdir -p "$SCRATCH"
+command cp "$REPO_ROOT/$TGZ_NAME" "$SCRATCH/sa.tgz"
+
+cd "$SCRATCH"
+echo '{}' > package.json
+echo "[consumer-smoke] installing from tarball"
+bun add ./sa.tgz >/dev/null 2>&1
+
+cat > repro.ts <<'TS'
+import { parse, findCalls, resolveFlags } from "@questi0nm4rk/shell-ast";
+import { unwrapCall } from "@questi0nm4rk/shell-ast/semantic";
+
+const ast = await parse("rm -rf /; sudo -u root rm /");
+const calls = findCalls(ast);
+if (calls.length !== 2) {
+  console.error(`FAIL: expected 2 calls, got ${calls.length}`);
+  process.exit(1);
+}
+const first = resolveFlags(calls[0]!);
+if (first?.cmd !== "rm") {
+  console.error(`FAIL: expected first cmd "rm", got ${first?.cmd}`);
+  process.exit(1);
+}
+const second = unwrapCall(calls[1]!);
+if (second?.wrapper !== "sudo" || second?.cmd !== "rm") {
+  console.error(`FAIL: expected sudo->rm, got wrapper=${second?.wrapper} cmd=${second?.cmd}`);
+  process.exit(1);
+}
+console.log("OK");
+TS
+
+echo "[consumer-smoke] running consumer script from $SCRATCH (not the repo)"
+bun run repro.ts
+echo "[consumer-smoke] PASS"


### PR DESCRIPTION
Closes #5 (v0.2.0 regression: every consumer outside the package dir crashes with ENOENT).

## What broke

In v0.2.0 the bundled \`dist/index.js\` ended up with:

\`\`\`js
var shell_ast_default = \"./shell-ast.wasm\";
const wasmBytes = await readFile(shell_ast_default);
\`\`\`

\`readFile\` resolves \`\"./shell-ast.wasm\"\` against \`process.cwd()\`. Every consumer running from anywhere except the package directory ENOENT'd on the first \`parse()\` call. hook-kit's upgrade to \`^0.2.0\` was the trigger that surfaced this.

## Same class as BUG-001

The audit (in main) named \"silent path-resolution failure\" as a bug class and locked the \`bun build --compile\` variant via \`tests/smoke/run-compile-smoke.sh\`. The analogous \`bun add\` install variant was never tested. v0.2.0 shipped the bug, and the install-from-tarball smoke that would have caught it was the test I owed the audit but didn't write.

## Fix

\`with { type: \"file\" }\` is still useful — it's what tells Bun's \`--compile\` to embed the asset and it gives an absolute path in dev. The issue is only the node-target bundler emitting a relative literal. Re-anchor in that one case:

\`\`\`ts
const here = dirname(fileURLToPath(import.meta.url));
const wasmPath = isAbsolute(wasmAsset)
  ? wasmAsset                                  // dev, --compile
  : join(here, wasmAsset.replace(/^\\\\.\\\\//, \"\"));  // consumer install
\`\`\`

Three modes verified:
| Mode | \`wasmAsset\` value | \`wasmPath\` result |
|---|---|---|
| dev (\`bun test\` against src/) | \`/abs/path/dist/shell-ast.wasm\` | unchanged absolute |
| consumer install | \`./shell-ast.wasm\` | \`<consumer's>/node_modules/.../dist/shell-ast.wasm\` |
| \`bun build --compile\` | \`/$bunfs/.../shell-ast.wasm\` | unchanged absolute |

## Regression lock

\`tests/smoke/run-consumer-install-smoke.sh\` (new) reproduces exactly what gh #5 reports:

1. \`bun pm pack\` the package
2. Install into a fresh \`/tmp/sa-consumer-\$\$/\` directory
3. Run a consumer script from THAT directory that calls \`parse\` + \`findCalls\` + \`unwrapCall\`

Wired into \`.github/workflows/ci.yml\` right after the compile smoke. Would have caught v0.2.0 before publish; will catch any future regression.

## Verification

- [x] \`bun test\` 99/99
- [x] \`go test\` 49/49
- [x] \`tests/smoke/run-compile-smoke.sh\` (BUG-001 still locked)
- [x] \`tests/smoke/run-consumer-install-smoke.sh\` PASS
- [x] Manual repro from gh #5: \`bun add + run from /tmp\` → OK

## After merge

- Publish 0.2.1
- Deprecate 0.2.0 on npm with a pointer to this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)