### PR TITLE
chore(ci): bump cc-review job timeout 30→60m

### DIFF
--- a/.github/workflows/cc-review-interactive.yml
+++ b/.github/workflows/cc-review-interactive.yml
@@ -31,7 +31,7 @@ jobs:
       contains(github.event.comment.body, '@cc-review') &&
       (github.event_name == 'pull_request_review_comment' ||
        (github.event_name == 'issue_comment' && github.event.issue.pull_request != null))
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/cc-review.yml
+++ b/.github/workflows/cc-review.yml
@@ -40,7 +40,7 @@ jobs:
     if: >-
       !contains(github.event.pull_request.labels.*.name, 'no-review') &&
       !contains(github.event.pull_request.user.login, '[bot]')
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: write        # push memory + ephemeral log branches
       pull-requests: write   # post reviews, resolve threads


### PR DESCRIPTION
**What:** raises the cc-review job `timeout-minutes` from 30 to 60 (in .github/workflows/cc-review.yml .github/workflows/cc-review-interactive.yml).

**Why:** the review job was being cancelled mid-review on large/complex PRs (a difficulty-5 review can run ~40m). 30m was too tight; the bot's core fixes are live but this cap lives in each repo's installed workflow (not runtime-cloned), so it needs bumping per repo.

**Verify:** 60m is a ceiling, not a fixed duration — normal PRs finish in minutes and the job exits early. No behavior change except large reviews no longer get cut off.